### PR TITLE
#10 : 뉴스 검색 결과 조회 기능 추가

### DIFF
--- a/news_agent/graph.py
+++ b/news_agent/graph.py
@@ -1,9 +1,8 @@
-import datetime
-
 from langgraph.graph import StateGraph, START, END
 from typing import Literal
 
 from nodes.input import get_user_input_from_cli
+from nodes.search_news import get_search_news_results
 from schema import NewsAgentState
 
 VALID_ARTICLE_COUNT = 3  # 3건 이상일 경우에만 응답해야 하는 요구사항 존재
@@ -28,12 +27,8 @@ def search_news_articles(state: NewsAgentState):
     :return:
     """
     print("search_news_articles")
-    # TODO : 실제 코드 작성 시 제거 요망
-    return {"articles": [{
-        "title": "hello",
-        "url": "hellp",
-        "published_at": datetime.datetime.now()
-    }]}
+    articles = get_search_news_results(state.get("input"))
+    return {"articles": articles}
 
 
 def check_article_exist(state: NewsAgentState) -> Literal["not_existed", "existed"]:

--- a/news_agent/nodes/search_news.py
+++ b/news_agent/nodes/search_news.py
@@ -1,0 +1,32 @@
+import os
+from typing import List
+
+from dotenv import load_dotenv
+from tavily import TavilyClient
+from datetime import datetime
+from news_agent.schema import Article
+
+load_dotenv()
+
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY")
+
+
+def get_search_news_results(question: str) -> List[Article]:
+    client = TavilyClient(api_key=TAVILY_API_KEY)
+    response = client.search(
+        query=question,
+        search_depth="advanced",
+        include_answer="basic",
+        exclude_domains=["youtube"]
+    )
+
+    results = []
+    for result in response.get("results"):
+        published_at = datetime.strptime(result.get("published_date"), '%a, %d %b %Y %H:%M:%S GMT') if result.get("published_date") else None
+        results.append(Article(title=result.get("title"), url=result.get("url"), published_at=published_at))
+    return results
+
+if __name__ == "__main__":
+    news = get_search_news_results("한덕수 국무총리에 대한 뉴스 주라")
+    print(news)
+


### PR DESCRIPTION
Tavily AI를 활용해서 검색어를 통해 뉴스를 찾아볼 수 있게 얼추 구현했습니다.

https://app.tavily.com

회원가입하면 월에 1000건 무료로 쓸 수 있으니 바로 토큰 쓰시면 됩니다~!
exclude_domains를 쓴 이유는 youtube 도메인이 들어간 항목은 검색 결과에서 제외하려고 넣었습니다.

```python
client = TavilyClient(api_key=TAVILY_API_KEY)
    response = client.search(
        query=question,
        search_depth="advanced",
        include_answer="basic",
        exclude_domains=["youtube"]
    )
```